### PR TITLE
Implement Hubs Dashboard

### DIFF
--- a/webapp/src/ChooseHub.vue
+++ b/webapp/src/ChooseHub.vue
@@ -1,8 +1,16 @@
 <template>
     <span>
-        <div class="choosehub ui floating dropdown black circular button p-1" data-tooltip="Create Connection" data-position="bottom left">
-            <i class="icon plus m-0"></i>
+        <div class="choosehub ui floating dropdown black circular button p-1">
+            <div data-tooltip="Create Connection" data-position="bottom left">
+              <i class="icon plus m-0"></i>
+            </div>
+
             <div class="menu largechoose">
+                <div class="item" data-value="open-hubs-dashboard">
+                  <i class="server circle icon"></i>
+                  <b>Open Hubs Dashboard</b>
+                </div>
+                <div class="divider"></div>
                 <div class="item" data-value="new">
                     <i class="plus circle icon"></i>
                     <b>Create new connection</b>
@@ -16,6 +24,10 @@
         </div>
 
         <div class="ui basic newhuburl modal">
+            <h3 class="ui icon open-hubs-dashboard" @click="openHubsDashboard">
+              <i class="server icon"></i>
+              Open Hubs Dashboard
+            </h3>
             <h3 class="ui icon">
                 <i class="plug icon"></i>
                 Create a new connection
@@ -70,18 +82,20 @@
               <ExistingConnections :existings="existings"></ExistingConnections>
             </div>
 
-        <div class="actions">
-          <div class="ui red basic cancel inverted button">
-              <i class="remove icon"></i>
-              Cancel
-          </div>
-          <div class="ui green ok inverted button" id="huburl_ok">
-              <i class="checkmark icon"></i>
-              OK
+          <div class="actions">
+            <div class="ui red basic cancel inverted button">
+                <i class="remove icon"></i>
+                Cancel
+            </div>
+            <div class="ui green ok inverted button" id="huburl_ok">
+                <i class="checkmark icon"></i>
+                OK
+            </div>
           </div>
         </div>
-    </div>
-</span>
+
+        <HubsDashboard :existings="existings"></HubsDashboard>
+    </span>
 
 </template>
 
@@ -91,16 +105,17 @@ import bus from './bus.js'
 import auth from './auth.js'
 import hubapi from './hubapi.js'
 import Vue from 'vue'
-
+import HubsDashboard from './HubsDashboard.vue'
 import ExistingConnections from './ExistingConnections.vue'
 import Loader from './Loader.vue'
 
-export default {
+export default {
   name: 'choose-hub',
   props: [],
   mixins: [Loader],
   components:{
     ExistingConnections,
+    HubsDashboard,
   },
   mounted () {
     this.getExistings()
@@ -109,6 +124,9 @@ export default {
       onChange: function (value, text, $selectedItem) {
         if (value == 'new') {
           self.newConnection()
+        }
+        if (value == 'open-hubs-dashboard') {
+          self.openHubsDashboard()
         }
       }
     })
@@ -248,6 +266,9 @@ export default {
       }
 
       this.refreshConnection(url)
+    },
+    openHubsDashboard: function() {
+      $('.hubs-dashboard.modal').modal('show')
     }
   }
 }
@@ -279,4 +300,7 @@ export default {
 
   .py-half-em {padding-top: 0.5em; padding-bottom: 0.5em}
 
+  .newhuburl .open-hubs-dashboard {
+    cursor: pointer;
+  }
 </style>

--- a/webapp/src/ExistingConnections.vue
+++ b/webapp/src/ExistingConnections.vue
@@ -82,5 +82,10 @@ export default {
   .ui.compact.table.hubconnect td {padding: .3em .0em .0em 0em;}
   .ui.compact.table.hubconnect {border-radius: unset; cursor: pointer;}
   .tdhubicon {padding: 0.3em 1em 0.3em 0.3em !important;}
-  .scrolling.menu {max-height: 15em; width: 62.5%; overflow: auto;}
+  .scrolling.menu {
+    max-height: 15em;
+    width: 62.5%;
+    overflow: auto;
+    background-color: white;
+  }
 </style>

--- a/webapp/src/HubInformation.vue
+++ b/webapp/src/HubInformation.vue
@@ -1,0 +1,230 @@
+<template>
+
+  <div :class="'ui card hub-info' + (show ? '' : ' hidden')">
+    <div class="content">
+      <div class="header">
+        <a class="popup ml-1"
+          v-if="!hub_info.online"
+          data-html="This hub is not accessible now."
+          data-position="top center"
+        >
+          <i class="red exclamation triangle icon"></i>
+        </a>
+        <a class="popup ml-1"
+          v-if="hub_info.errors && hub_info.errors.length > 0"
+          :data-html="hub_info.errors.join('<br>')"
+          data-position="top center"
+        >
+          <i class="red exclamation triangle icon"></i>
+        </a>
+
+        <a class="popup ml-1"
+          v-if="hub_info.whatsnew && Object.keys(hub_info.whatsnew).length > 0"
+          :data-html="`<pre>${JSON.stringify(hub_info.whatsnew, null, 2)}</pre>`"
+          data-position="top center"
+        >
+          <i class="blue bell icon"></i>
+        </a>
+        <span @click="connect"
+          class="popup hub-name-wrapper"
+          :data-html="'Click to connect to <b>' + hub_info.name + '</b>'"
+          data-position="top center"
+        >
+          <img class="hub-icon" :src="hub_info.icon" >
+          <span class="hub-name">{{ hub_info.name }}</span>
+        </span>
+
+        <div class="meta">
+          <small>Last updated: {{ moment(hub_info.last_updated).format('MM/DD/YYYY HH:mm:ss a') }}</small>
+        </div>
+      </div>
+
+      <div class="description">
+        <div :class="hub_info.fetching_counter > 0? 'ui active dimmer' : '' "><div class="ui loader"></div></div>
+        <table class="ui table very compact">
+          <tbody>
+            <tr>
+              <td># of sources</td>
+              <td>{{ hub_info.source.total | formatInteger }}</td>
+            </tr>
+            <tr>
+              <td># of documents</td>
+              <td>{{ hub_info.source.documents | formatNumber }}</td>
+            </tr>
+            <tr>
+              <td># of builts</td>
+              <td>{{ hub_info.build.total | formatInteger }}</td>
+            </tr>
+            <tr>
+              <td># of active proceses</td>
+              <td>{{ hub_info.running_processes | formatInteger }}</td>
+            </tr>
+            <tr>
+              <td># of active threads</td>
+              <td>{{ hub_info.running_threads | formatInteger }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="extra content light-grey">
+      <button class="ui button mini icon" @click="hide" data-tooltip="Hide this hub">
+        <i class="eye icon"></i>
+      </button>
+
+      <button class="ui button mini right floated" @click="(event) => {refresh()}">
+        <i class="sync alternate icon"></i>
+        Refresh
+      </button>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+import axios from 'axios'
+
+export default {
+  name: 'HubInformation',
+  props: ["hub_config", "show"],
+  data () {
+    return {
+      hub_info: {
+        name: this.hub_config.name,
+        icon: this.hub_config.icon,
+        url: this.hub_config.url,
+        whatsnew: this.hub_config.whatsnew || {},
+        errors: this.hub_config.errors || [],
+        source: {total: 0, documents: 0},
+        build: {total: 0},
+        running_processes: 0,
+        running_threads: 0,
+        online: true,
+        fetching_counter: 0,
+        last_updated: null,
+      },
+      ticker: 0,
+    }
+  },
+  updated () {
+    $(".hub-info .popup").popup()
+  },
+  methods: {
+    tick: function() {
+      this.ticker += 1
+    },
+    hide: function () {
+      this.$parent.toggleHub(this.hub_info.name, false)
+    },
+    connect: function () {
+      this.$parent.connect(this.hub_info.name)
+    },
+    refresh: function () {
+      const self = this
+
+      self.hub_info.last_updated = new Date()
+      self.hub_info.fetching_counter = 3 // 3 tasks: whatsnew, status, job manager
+
+      setTimeout(() => {
+        // Fetch hub's whatsnew
+        axios.get(self.hub_config.url + '/whatsnew')
+        .then(response => {
+          self.hub_info.whatsnew = response.data.result
+          self.hub_info.online = true
+          self.hub_info.fetching_counter -= 1
+          self.tick()
+        })
+        .catch(err => {
+          if (err && err.message === "Network Error") {
+            self.hub_info.online = false
+          }
+          else {
+            self.hub_info.errors.push("Failed to get whats new.")
+          }
+
+          self.hub_info.fetching_counter -= 1
+          self.tick()
+
+          console.log(`Error getting hub ${self.hub_config.name}'s whatsnew: ${err}`)
+        })
+
+      // Fetch hub's status
+      axios.get(self.hub_config.url + '/status')
+        .then(response => {
+          self.hub_info.source = response.data.result.source
+          self.hub_info.build = response.data.result.build
+          self.hub_info.online = true
+          self.hub_info.fetching_counter -= 1
+          self.tick()
+        })
+        .catch(err => {
+          if (err && err.message === "Network Error") {
+            self.hub_info.online = false
+          }
+          else {
+            self.hub_info.errors.push("Failed to get status information.")
+          }
+
+          self.hub_info.fetching_counter -= 1
+          self.tick()
+
+          console.log(`Error getting hub ${self.hub_config.name}'s status: ${err}`)
+        })
+
+      // Fetch hub's job information
+      axios.get(self.hub_config.url + '/job_manager')
+        .then(response => {
+          self.hub_info.active_processes = response.data.result.processes?.running
+          self.hub_info.active_threads = response.data.result.threads?.running
+          self.hub_info.online = true
+          self.hub_info.fetching_counter -= 1
+          self.tick()
+        })
+        .catch(err => {
+          if (err && err.message === "Network Error") {
+            self.hub_info.online = false
+          }
+          else {
+            self.hub_info.errors.push("Failed to get job information.")
+          }
+
+          self.hub_info.fetching_counter -= 1
+          self.tick()
+
+          console.log(`Error getting hub ${self.hub_config.name}'s job manager: ${err}`)
+        })
+      }, 1000)
+    },
+  }
+}
+</script>
+
+
+<style scoped>
+.ml-1 {
+  margin-left: 0.3rem;
+}
+
+.hub-icon {
+  width: 1.5rem;
+  margin-right: 0.5rem;
+}
+
+.hub-info.hidden {
+  display: none;
+}
+
+.hub-info .header {
+  font-size: 1.1rem;
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+}
+
+.hub-info .header .hub-name-wrapper {
+  cursor: pointer;
+}
+
+</style>

--- a/webapp/src/HubsDashboard.vue
+++ b/webapp/src/HubsDashboard.vue
@@ -1,0 +1,156 @@
+<template>
+<div class="ui hubs-dashboard large modal">
+  <div class="header">Hubs Dashboard</div>
+
+  <div class="content scrolling">
+    <div class="ui flex justify-evenly flex-wrap" v-if="hubs_infos">
+      <div class="ui card"
+          v-for="(hub_info, hub_name) in hubs_infos"
+          :key="hub_name + ticker"
+          @click="changeConnection($event, hub_name)"
+      >
+        <div class="content">
+          <div class="header">
+            <img class="hub-icon" :src="hub_info.icon" >
+            <span class="hub-name">{{ hub_name }}</span>
+          </div>
+
+          <div class="description">
+            <table class="ui table very compact">
+              <tbody>
+                <tr class="text red" v-if="hub_info.errors">
+                  <td>Errors</td>
+                  <td>{{ hub_info.errors.join('; ') }}</td>
+                </tr>
+                <tr class="text info" v-if="hub_info.whatsnew">
+                  <td>Whats New</td>
+                  <td>{{ hub_info.whatsnew }}</td>
+                </tr>
+                <tr>
+                  <td># of sources</td>
+                  <td>{{ hub_info.source.total }}</td>
+                </tr>
+                <tr>
+                  <td># of documents</td>
+                  <td>{{ hub_info.source.documents }}</td>
+                </tr>
+                <tr>
+                  <td># of builts</td>
+                  <td>{{ hub_info.build.total }}</td>
+                </tr>
+                <tr>
+                  <td># of active proceses</td>
+                  <td>{{ hub_info.running_processes }}</td>
+                </tr>
+                <tr>
+                  <td># of active threads</td>
+                  <td>{{ hub_info.running_threads }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="actions">
+      <div class="ui black cancel button">
+        Close
+      </div>
+      <div class="ui primary button" @click="switchToSimpleMode($event)">
+        Switch to simple mode
+      </div>
+    </div>
+</div>
+
+</template>
+
+
+<script>
+import axios from 'axios'
+import Vue from 'vue'
+import Loader from './Loader.vue'
+
+export default {
+  name: 'HubsDashboard',
+  props: ["existings"],
+  mixins: [],
+  components: {},
+  data () {
+    return {
+      hubs_infos: {},
+      ticker: 0,
+    }
+  },
+  mounted () {
+    const self = this
+    $(".modal").modal('setting', {
+      onShow: function() {
+        self.getHubsInfos()
+      }
+    })
+  },
+  methods: {
+    changeConnection: function(event, hub_name) {
+      console.log(hub_name)
+      this.$parent.changeConnection(hub_name)
+    },
+    switchToSimpleMode: function (event) {
+      this.$parent.newConnection()
+    },
+    getHubInfo: function (hub_config) {
+      const self = this
+
+      self.hubs_infos[hub_config.name] = {
+        name: hub_config.name,
+        icon: hub_config.icon,
+        url: hub_config.url,
+        whatsnew: hub_config.whatsnew,
+        errors: hub_config.errors,
+        source: {total: 0, documents: 0},
+        build: {total: 0},
+        running_processes: 0,
+        running_threads: 0,
+      }
+
+      axios.get(hub_config.url + '/status')
+        .then(response => {
+          self.hubs_infos[hub_config.name].source = response.data.result.source
+          self.hubs_infos[hub_config.name].build = response.data.result.build
+          this.ticker += 1
+        })
+        .catch(err => {
+          console.log(`Error getting hub ${hub_config.name}'s status: ${err}`)
+        })
+
+      axios.get(hub_config.url + '/job_manager')
+        .then(response => {
+          self.hubs_infos[hub_config.name].active_processes = response.data.result.processes?.running
+          self.hubs_infos[hub_config.name].active_threads = response.data.result.threads?.running
+          this.ticker += 1
+        })
+        .catch(err => {
+          console.log(`Error getting hub ${hub_config.name}'s job manager: ${err}`)
+        })
+    },
+    getHubsInfos: function() {
+      this.hubs_infos = {}
+      Object.values(this.existings).forEach(this.getHubInfo)
+    }
+  }
+}
+</script>
+
+
+<style scoped>
+.hub-icon {
+  width: 1.5rem;
+  margin-right: 0.5rem;
+}
+
+.hubs-dashboard.ui.modal>.scrolling.content {
+  max-height: calc(90vh - 5rem);
+}
+
+</style>


### PR DESCRIPTION
This PR implements a new Dashboard, which will show all existing Hub connections, with some basic information

- [x] The dashboard should show all hubs (one hub as one box/tile) in a grid view
- [x] Each hub tile should display some basic information (name, logo, some stats likes # of data srcs, builds etc, # of active tasks)
- [x] Click a tile should connect to that hub
- [x] Should have an interface to customize the hubs to be included in the dashboard, or other preferences. These preferences can be saved on browser-side
- [x] Some hubs may not be accessible at a particular moment, which is fine and should not impact the display of other working hub tile.
- [x] Should allow to switch between the dashboard view or the current connection view as the default landing page. The preference can be saved on browser-side as well.

Ref: https://github.com/biothings/biothings_studio/issues/110
