### PR TITLE
fix error when creating new Hub connection, which has no name, icon

### DIFF
--- a/webapp/src/ChooseHub.vue
+++ b/webapp/src/ChooseHub.vue
@@ -177,8 +177,8 @@ export default {
           var data = response.data.result
           self.getExistings()
           data.url = url.replace(/\/$/, '')
-          if (!data.name) { data.name = self.$parent.default_conn.name }
-          if (!data.icon) { data.icon = self.$parent.default_conn.icon }
+          if (!data.name) { data.name = self.$parent.$parent.default_conn.name }
+          if (!data.icon) { data.icon = self.$parent.$parent.default_conn.icon }
           self.existings[data.name] = data
           Vue.localStorage.set('hub_connections', JSON.stringify(self.existings))
           // update base URL for all API calls


### PR DESCRIPTION
When a Hub backend has no name, and/or icon, the studio will apply default values got from App component, the current logic has a bug in that logic, it tries to access incorrect component.

Screenshot:
![Screenshot from 2024-01-25 16-35-54](https://github.com/newgene/biothings_studio/assets/73963722/a4b1190f-5294-4dd2-b990-d7d73c52237c)
